### PR TITLE
Support for Laravel 10,

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/contracts": "^9.0"
+        "php": "^8.0"
     },
     "require-dev": {
         "nunomaduro/collision": "^6.0",


### PR DESCRIPTION
Hi maintainers,

This pull request aims to remove the requirement for illuminate/contracts in this package, bringing support for Laravel 10 and higher versions.

**Rationale**:

As of Laravel 10, the functionality of illuminate/contracts has been merged into laravel/framework. Including both packages simultaneously creates conflicts and is unnecessary for Laravel 10+ projects.