### PR TITLE
Rename to scopeForKey

### DIFF
--- a/src/Models/Projection.php
+++ b/src/Models/Projection.php
@@ -103,7 +103,7 @@ class Projection extends Model
     /**
      * Scopes a query to filter by key.
      */
-    public function scopeKey(Builder $query, array|string|int $keys): Builder
+    public function scopeForKey(Builder $query, array|string|int $keys): Builder
     {
         if (is_array($keys)) {
             return $query->where(function ($query) use (&$keys) {

--- a/tests/ProjectionTest.php
+++ b/tests/ProjectionTest.php
@@ -149,7 +149,7 @@ class ProjectionTest extends TestCase
         $log = $this->createModelWithProjections(Log::class, [SinglePeriodProjectionWithUniqueKey::class]);
         $this->createModelWithProjections(Log::class, [SinglePeriodProjectionWithUniqueKey::class]);
 
-        $numberOfProjections = Projection::key($log->id)->count();
+        $numberOfProjections = Projection::forKey($log->id)->count();
 
         $this->assertEquals(1, $numberOfProjections);
     }
@@ -160,7 +160,7 @@ class ProjectionTest extends TestCase
         $log = $this->createModelWithProjections(Log::class, [SinglePeriodProjectionWithUniqueKey::class]);
         $anotherLog = $this->createModelWithProjections(Log::class, [SinglePeriodProjectionWithUniqueKey::class]);
 
-        $numberOfProjections = Projection::key([$log->id, $anotherLog->id])->count();
+        $numberOfProjections = Projection::forKey([$log->id, $anotherLog->id])->count();
 
         $this->assertEquals(2, $numberOfProjections);
     }


### PR DESCRIPTION
This fixes the issue the function key() of the projectable overlaps with scopeKey. The latter is renamed to scopeForKey as that was fix with the lowest impact. 