### PR TITLE
Fix Carbon\Carbon::rawAddUnit() string error

### DIFF
--- a/src/Collections/ProjectionCollection.php
+++ b/src/Collections/ProjectionCollection.php
@@ -196,7 +196,7 @@ class ProjectionCollection extends Collection
         [$periodQuantity, $periodType] = Str::of($period)->split('/[\s]+/');
 
         while ($cursorDate->notEqualTo($endDate)):
-            $cursorDate->add($periodQuantity, $periodType);
+            $cursorDate->add((float)$periodQuantity, $periodType);
 
             if ($cursorDate->notEqualTo($endDate)) {
                 $allProjectionsDates->push(clone $cursorDate);


### PR DESCRIPTION
Carbon::add call expects a float or int for value but string was provided in ProjectionCollection getAllPeriods causing fatal error.

Fixed by casting $periodQuantity to float.